### PR TITLE
Refactored CombinedClustering

### DIFF
--- a/hs2.py
+++ b/hs2.py
@@ -254,7 +254,7 @@ class herdingspikes(object):
                 logging.warn("Cluster {0} has no spikes associated. Setting ctr_x,ctr_y,Size,AvgAmp[{0}] all to 0".format(i))
                 continue
 
-            self.centers[i] = np.mean(self.fourvec[cl_spikes_idxs][:,:2], axis=0)
+            self.centers[i] = np.mean(self.fourvec[cl_spikes_idxs][:, :2], axis=0)
             sizes[i] = cl_spikes_idxs.shape[0]
             amps[i] = np.mean(self.spikes.Amplitude[cl_spikes_idxs])
 


### PR DESCRIPTION
Now uses pure numpy to compute centers, sizes & avgAmps of all clusters.

Also doesn't throw KeyError & FutureWarning when MeanShift's `min_bin_freq` set to 0.