### PR TITLE
Use an optional environment variable 'HS2_PROBE_PATH' to write probe files

### DIFF
--- a/herdingspikes/probe.py
+++ b/herdingspikes/probe.py
@@ -37,13 +37,21 @@ def create_probe_files(pos_file, neighbor_file, radius, ch_positions):
             f.write("{},\n".format(str(list(neighbors))[1:-1]))
     f.close()
 
-
+#JJJ modified
 def in_probes_dir(file):
-    return os.path.join(this_file_path, "probes", file)
+    probe_path1 = os.getenv('HS2_PROBE_PATH', this_file_path)    
+    probe_path = os.path.join(probe_path1, "probes")
+    if not os.path.exists(probe_path):
+        os.mkdir(probe_path)
+    return os.path.join(probe_path, file)
 
-
+#JJJ modified
 def in_probe_info_dir(file):
-    return os.path.join(this_file_path, "probe_info", file)
+    probe_path1 = os.getenv('HS2_PROBE_PATH', this_file_path)    
+    probe_path = os.path.join(probe_path1, "probe_info")
+    if not os.path.exists(probe_path):
+        os.mkdir(probe_path)
+    return os.path.join(probe_path, file)
 
 
 class NeuralProbe(object):


### PR DESCRIPTION
Previously "probes" and "probe_info" directories were created in the source code directory. This could be problematic when running the code in a singularity container. The new version creates the probe files under  `HS2_PROBE_PATH`  if the environment variable is set. 

The new version also creates 'probes' and 'probe_info' directories if they do not exist. Original code threw errors when the directories do not exist.