### PR TITLE
Added version and commit information

### DIFF
--- a/herdingspikes/__init__.py
+++ b/herdingspikes/__init__.py
@@ -3,4 +3,6 @@ from herdingspikes import probe
 # from herdingspikes.parameter_optimisation import OptimiseParameters
 from herdingspikes.hs2 import HSDetection, HSClustering
 
-__all__ = ["probe", "OptimiseParameters", "HSDetection", "HSClustering"]
+from herdingspikes.version import __version__, __commit__, base_version
+
+__all__ = ["probe", "OptimiseParameters", "HSDetection", "HSClustering", "__version__"]

--- a/herdingspikes/version.py
+++ b/herdingspikes/version.py
@@ -1,0 +1,29 @@
+import subprocess
+import os
+
+__version__ = '0.3.3'
+base_version = __version__
+
+__commit__ = ''
+try:
+    _hsPath = os.path.abspath(os.path.dirname(__file__))
+    _commitFile = os.path.join(_hsPath, '.commit_version')
+    if os.path.exists(_commitFile):
+        with open(_commitFile) as f:
+            __commit__ = f.read().strip()
+    else:
+        __commit__ = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=_hsPath).decode('utf8').strip()
+except:
+    pass
+
+
+if __commit__:
+    __version__ = __version__ + '+git.' + __commit__[:12]
+
+del _hsPath, _commitFile, os, subprocess
+
+__all__ = [
+    "__version__",
+    "__commit__",
+    "base_version"
+]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,29 @@ import platform
 import numpy
 from distutils.version import LooseVersion
 
+import sys
+
 FOLDER = "herdingspikes/detection_localisation/"
+
+
+def get_pkg_version():
+    version = {}
+    version['__file__'] = __file__
+
+    # Because __init__.py in herdingspikes loads packages we may not have installed yet, we need to parse version.py directly
+    # (see https://packaging.python.org/guides/single-sourcing-package-version/)
+    with open("herdingspikes/version.py") as fp:
+        exec(fp.read(), version)
+
+    # Store the commit hash for when we don't have access to git
+    with open("herdingspikes/.commit_version", 'w') as cf:
+        cf.write(version['__commit__'])
+
+    # Public versions should not contain local identifiers (inspired from mypy)
+    if any(cmd in sys.argv[1:] for cmd in ('install', 'bdist_wheel', 'sdist')):
+        return version['base_version']
+    else:
+        return version['__version__']
 
 use_cython = False
 # do not use it if cython is not installed
@@ -86,7 +108,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.3',  # Required
+    version=get_pkg_version(),  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
@@ -206,7 +228,8 @@ setup(
     # If using Python 2.6 or earlier, then these have to be included in
     # MANIFEST.in as well.
     package_data={  # Optional
-        'herdingspikes': ['probe_info/neighbormatrix*',  # probe data
+        'herdingspikes': ['.commit_version', 
+                          'probe_info/neighbormatrix*',  # probe data
                           'probe_info/positions*',
                           # needed for setup's long_description
                           '../README.md',
@@ -252,3 +275,4 @@ setup(
 )
 
 os.remove(os.path.join(FOLDER, "detect.cpp"))
+os.remove("herdingspikes/.commit_version")


### PR DESCRIPTION
Hi,

I figured these changes may help implement https://github.com/mhhennig/HS2/issues/39

"base_version" is the usual version you have used before, "`__version__`" has the first 12 characters of the commit hash appended to it and "`__commit__`" is the full hash.

If git is available, the commit hash is stored within the packages created via setup.py `bdist_wheel`, `sdist` and `install`. The public version will use "base_version".

To try, simply use:
```
import herdingspikes
print(herdingspikes.__version__)
```
or
```
print(herdingspikes.version.__commit__)
```

Hope you find it helpful.
