### PR TITLE
Fix relative imports, slightly better BRW v4.x support

### DIFF
--- a/herdingspikes/hs2.py
+++ b/herdingspikes/hs2.py
@@ -1003,7 +1003,7 @@ class HSClustering(object):
             ax.append(plt.subplot2grid((len(clInds) + 1, 4), (i, 3), colspan=1))
             ax[i + 1].axis("off")
             if i > 0:
-                ax[i].get_shared_y_axes().join(ax[i], ax[i + 1])
+                ax[i].sharey(ax[i + 1])
 
         for i_cl, cl_t in enumerate(clInds):
             cx, cy = self.clusters["ctr_x"][cl_t], self.clusters["ctr_y"][cl_t]

--- a/herdingspikes/probe.py
+++ b/herdingspikes/probe.py
@@ -2,12 +2,12 @@ from __future__ import division
 import numpy as np
 import json
 from matplotlib import pyplot as plt
-from probe_functions.readUtils import read_flat
-from probe_functions.readUtils import openHDF5file, getHDF5params, getHDF5params_brw4
-from probe_functions.readUtils import readHDF5t_100, readHDF5t_101
-from probe_functions.readUtils import readHDF5t_100_i, readHDF5t_101_i
-from probe_functions.readUtils import readHDF5_brw4
-from probe_functions.neighborMatrixUtils import createNeighborMatrix
+from .probe_functions.readUtils import read_flat
+from .probe_functions.readUtils import openHDF5file, getHDF5params, getHDF5params_brw4
+from .probe_functions.readUtils import readHDF5t_100, readHDF5t_101
+from .probe_functions.readUtils import readHDF5t_100_i, readHDF5t_101_i
+from .probe_functions.readUtils import readHDF5_brw4
+from .probe_functions.neighborMatrixUtils import createNeighborMatrix
 import h5py
 import ctypes
 import os.path

--- a/herdingspikes/probe_functions/readUtils.py
+++ b/herdingspikes/probe_functions/readUtils.py
@@ -58,7 +58,7 @@ def getHDF5params_brw4(rf):
     samplingRate = exp_setting['TimeConverter']['FrameRate']
     signalInv = exp_setting['ValueConverter']['ScaleFactor']
     file_format = 'brw4'
-    print('NEW IMPL')
+
     for key in rf:
         if key.startswith("Well_"):
             nFrames = int((len(rf[key]['Raw']))/len(rf[key]['StoredChIdxs']))

--- a/herdingspikes/probe_functions/readUtils.py
+++ b/herdingspikes/probe_functions/readUtils.py
@@ -54,20 +54,23 @@ def getHDF5params(rf):
 def getHDF5params_brw4(rf):
 
     exp_setting = json.loads(rf['ExperimentSettings'].asstr()[0])
-    nFrames = int((len(rf['Well_A1']['Raw']))/len(rf['Well_A1']['StoredChIdxs']))
+    
     samplingRate = exp_setting['TimeConverter']['FrameRate']
     signalInv = exp_setting['ValueConverter']['ScaleFactor']
     file_format = 'brw4'
-
-    # Get the actual number of channels used in the recording
-    nRecCh = len(rf['Well_A1']['StoredChIdxs'])
+    print('NEW IMPL')
+    for key in rf:
+        if key.startswith("Well_"):
+            nFrames = int((len(rf[key]['Raw']))/len(rf[key]['StoredChIdxs']))
+            # Get the actual number of channels used in the recording
+            nRecCh = len(rf[key]['StoredChIdxs'])
+            # Compute indices
+            chIndices = rf[key]['StoredChIdxs'][()].tolist()
 
     print('# 3Brain data format:', 'BRW v4.x', 'signal inversion', signalInv)
     print('#       signal range: ', exp_setting['ValueConverter']['MinAnalogValue'], '- ',
           exp_setting['ValueConverter']['MaxAnalogValue'])
-    # Compute indices
-    chIndices = rf['Well_A1']['StoredChIdxs'][()].tolist()
-
+    
     return (nFrames, samplingRate, nRecCh, chIndices, file_format, signalInv)
 
 def readHDF5(rf, t0, t1):
@@ -113,17 +116,19 @@ def readHDF5t_101(rf, t0, t1, nch):
 
 def readHDF5_brw4(rf, t0, t1, nch):
     ''' Transposed version for the interpolation method. '''
-    if t0 <= t1:
-        d = rf['Well_A1/Raw'][nch*t0:nch*t1].reshape(
-            (-1, nch), order='C').flatten('C').astype(ctypes.c_short)-2048
-        d[np.abs(d) > 1500] = 0
-        return d
-    else:  # Reversed read
-        raise Exception('Reading backwards? Not sure about this.')
-        d = rf['3BData/Raw'][nch*t1:nch*t0].reshape(
-            (-1, nch), order='C').flatten('C').astype(ctypes.c_short)-2048
-        d[np.where(np.abs(d) > 1500)[0]] = 0
-        return d
+    for key in rf:
+        if key.startswith("Well_"):
+            if t0 <= t1:
+                d = rf[key]['Raw'][nch*t0:nch*t1].reshape(
+                    (-1, nch), order='C').flatten('C').astype(ctypes.c_short)-2048
+                d[np.abs(d) > 1500] = 0
+                return d
+            else:  # Reversed read
+                raise Exception('Reading backwards? Not sure about this.')
+                d = rf['3BData/Raw'][nch*t1:nch*t0].reshape(
+                    (-1, nch), order='C').flatten('C').astype(ctypes.c_short)-2048
+                d[np.where(np.abs(d) > 1500)[0]] = 0
+                return d
 
 def readHDF5t_101_i(rf, t0, t1, nch):
     ''' Transposed version for the interpolation method. '''

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    setup_requires=['numpy >= 1.14', 'scipy'],
+    setup_requires=['numpy >= 1.14', 'scipy','cython >= 3.0.0'],
     install_requires=['h5py', 'matplotlib >= 2.0',
                       'pandas', 'scikit-learn >= 0.19.1',
                       'joblib', 'six'],


### PR DESCRIPTION
Fixes relative imports in `probe.py` since last PR.
Small change in the handling of "wells" in newer BRW recordings, based on neo's implementation (see NeuralEnsemble/python-neo#1326).