### PR TITLE
LoadDetected for Lightning and a few fixes

### DIFF
--- a/herdingspikes/hs2.py
+++ b/herdingspikes/hs2.py
@@ -508,8 +508,7 @@ class HSDetectionLightning(object):
                     "samples.",
                 )
         if self.out_file_name is not None:
-            out_dir = os.path.dirname(self.out_file_name)
-            self.spikes_file = Path(out_dir).joinpath(str(self.out_file_name) + ".hdf5")
+            self.spikes_file = Path(str(self.out_file_name) + ".hdf5")
 
     def DetectFromRaw(self):
         """


### PR DESCRIPTION
Implements `LoadDetected` for `HSDetectionLightning`.

Essentially adapted from the one already in use with `HSDetection`. Not sure if returning a dict with empy lists in case of an empty file is the right move, maybe arrays would be more appropriate ?

A few other things : 

 - `out_dir` was unused. `spikes_file` is also correct whether `out_file_name` is `str` or `Path`.
 - Waveforms weren't saved even when `save_shape` was set to `True`. I used the same code as for `HSDetection` to save it to HDF5. Don't know if you want to keep the ability to compress this dataset.
 - Line 5 commented out for now, probably removable ? See #84 